### PR TITLE
Update fileGroups.json with my tools

### DIFF
--- a/fileGroups.json
+++ b/fileGroups.json
@@ -21,5 +21,13 @@
 		"File:Krinkle insertVectorButtons.js": "InsertVectorButtons",
 		"File:Krinkle mwEditsectionZero.js": "mwEditsectionZero",
 		"File:Krinkle toggleRevDel.js": "ToggleRevDel"
+	},
+	"Pathoschild": {
+		"File:Pathoschild/ajaxsysop.js": "Ajax sysop",
+		"File:Pathoschild/filterrc.js": "FilterRC",
+		"File:Pathoschild/forceltr.js": "Force ltr",
+		"File:Pathoschild/stewardscript.js": "StewardScript",
+		"File:Pathoschild/templatescript.js": "TemplateScript",
+		"File:Pathoschild/usejs.js": "UseJS"
 	}
 }


### PR DESCRIPTION
This commit updates `fileGroups.json` to add [ajax sysop](//meta.wikimedia.org/wiki/User:Pathoschild/Scripts/Ajax_sysop), [filterRC](//meta.wikimedia.org/wiki/User:Pathoschild/Scripts/FilterRC.js), [force ltr](//meta.wikimedia.org/wiki/Force_ltr), [StewardScript](//meta.wikimedia.org/wiki/StewardScript), [TemplateScript](//meta.wikimedia.org/wiki/TemplateScript), and [useJS](//meta.wikimedia.org/wiki/UseJS). (Some of these might not show any usages, which is expected since I've only recently started adding the tracker code and haven't updated all uses yet.)

Thanks for offering to add my scripts to your tool. :)
